### PR TITLE
chore: bump lmeval version

### DIFF
--- a/redhat-distribution/Containerfile
+++ b/redhat-distribution/Containerfile
@@ -5,7 +5,7 @@ FROM --platform=linux/amd64 quay.io/aipcc/base-images/cpu:2.0-1749153990
 WORKDIR /opt/app-root
 
 RUN pip install sqlalchemy # somehow sqlalchemy[asyncio] is not sufficient
-RUN pip install aiosqlite autoevals chardet datasets fastapi fire httpx kubernetes llama_stack_provider_lmeval==0.1.3 llama_stack_provider_trustyai_fms==0.1.2 matplotlib mcp nltk numpy openai opentelemetry-exporter-otlp-proto-http opentelemetry-sdk pandas pillow psycopg2-binary pymilvus pymongo pypdf redis requests scikit-learn scipy sentencepiece sqlalchemy[asyncio] tqdm transformers uvicorn
+RUN pip install aiosqlite autoevals chardet datasets fastapi fire httpx kubernetes llama_stack_provider_lmeval==0.1.4 llama_stack_provider_trustyai_fms==0.1.2 matplotlib mcp nltk numpy openai opentelemetry-exporter-otlp-proto-http opentelemetry-sdk pandas pillow psycopg2-binary pymilvus pymongo pypdf redis requests scikit-learn scipy sentencepiece sqlalchemy[asyncio] tqdm transformers uvicorn
 RUN pip install --index-url https://download.pytorch.org/whl/cpu torch torchvision
 RUN pip install --no-deps sentence-transformers
 RUN pip install --no-cache llama-stack==0.2.10

--- a/redhat-distribution/providers.d/remote/eval/trustyai_lmeval.yaml
+++ b/redhat-distribution/providers.d/remote/eval/trustyai_lmeval.yaml
@@ -1,6 +1,6 @@
 adapter:
   adapter_type: trustyai_lmeval
-  pip_packages: ["kubernetes", "llama_stack_provider_lmeval==0.1.3"]
+  pip_packages: ["kubernetes", "llama_stack_provider_lmeval==0.1.4"]
   config_class: llama_stack_provider_lmeval.config.LMEvalEvalProviderConfig
   module: llama_stack_provider_lmeval
 api_dependencies: ["inference"]


### PR DESCRIPTION
To get this patch
https://github.com/trustyai-explainability/llama-stack-provider-lmeval/pull/25. This means that lmeval config doesn't need a "namespace" field explicitly.
LMEval will:

* look for a config.namespace
* if not found, will search for TRUSTYAI_LM_EVAL_NAMESPACE env var
* if not found, will use the value of "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
