### PR TITLE
ci: add a build and push action

### DIFF
--- a/.github/workflows/redhat-distro-container-build.yml
+++ b/.github/workflows/redhat-distro-container-build.yml
@@ -1,0 +1,41 @@
+name: Build and Publish Redhat Distribution Container
+
+on:
+  pull_request:
+    branches:
+      - rhoai-v*
+  push:
+    branches:
+      - rhoai-v*
+
+env:
+  REGISTRY: quay.io
+  IMAGE_NAME: quay.io/opendatahub/llama-stack:odh
+  LOCAL_BUILD_IMAGE: localhost/rh
+
+jobs:
+  build-and-push:
+    name: Build and Push Container
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build image
+        id: build
+        run: |
+          docker build --platform linux/amd64 -f redhat-distribution/Containerfile -t ${{ env.LOCAL_BUILD_IMAGE }} .
+
+      - name: Log in to Quay.io
+        if: github.event_name == 'push'
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Push image
+        if: github.event_name == 'push'
+        run: |
+          docker push ${{ env.LOCAL_BUILD_IMAGE }} ${{ env.IMAGE_NAME }}


### PR DESCRIPTION
* Build an image on every PRs against the rhoai-v2.22 branch
* Push and image on every push to the rhoai-v2.22 branch


ON TOP OF https://github.com/opendatahub-io/llama-stack/pull/8