### PR TITLE
feat: change embedding model to granite

### DIFF
--- a/redhat-distribution/run.yaml
+++ b/redhat-distribution/run.yaml
@@ -112,9 +112,10 @@ models:
   provider_id: vllm-inference
   model_type: llm
 - metadata:
-    embedding_dimension: 384
-  model_id: all-MiniLM-L6-v2
+    embedding_dimension: 768
+  model_id: granite-embedding-125m
   provider_id: sentence-transformers
+  provider_model_id: ibm-granite/granite-embedding-125m-english
   model_type: embedding
 shields: []
 vector_dbs: []


### PR DESCRIPTION
Tested locally.
Server logs, we can see sentence-transformers loading our model granite model:

```
INFO     2025-06-18 10:51:41,580 __main__:432 server: Using config file: llama_stack/templates/ollama/run.yaml
INFO     2025-06-18 10:51:41,582 __main__:434 server: Run configuration:
INFO     2025-06-18 10:51:41,587 __main__:436 server: apis:
         - agents
         - datasetio
         - eval
         - inference
         - post_training
         - safety
         - scoring
         - telemetry
         - tool_runtime
         - vector_io
         benchmarks: []
         container_image: null
         datasets: []
         external_providers_dir: null
         image_name: ollama
         inference_store:
           db_path: /Users/leseb/.llama/distributions/ollama/inference_store.db
           type: sqlite
         logging: null
         metadata_store:
           db_path: /Users/leseb/.llama/distributions/ollama/registry.db
           namespace: null
           type: sqlite
         models:
         - metadata: {}
           model_id: llama3.2:3b
           model_type: !!python/object/apply:llama_stack.apis.models.models.ModelType
           - llm
           provider_id: ollama
           provider_model_id: null
         - metadata:
             embedding_dimension: 768
           model_id: granite-embedding-125m
           model_type: !!python/object/apply:llama_stack.apis.models.models.ModelType
           - embedding
           provider_id: sentence-transformers
           provider_model_id: ibm-granite/granite-embedding-125m-english
         providers:
           agents:
           - config:
               persistence_store:
                 db_path: /Users/leseb/.llama/distributions/ollama/agents_store.db
                 namespace: null
                 type: sqlite
               responses_store:
                 db_path: /Users/leseb/.llama/distributions/ollama/responses_store.db
                 type: sqlite
             provider_id: meta-reference
             provider_type: inline::meta-reference
           datasetio:
           - config:
               kvstore:
                 db_path: /Users/leseb/.llama/distributions/ollama/huggingface_datasetio.db
                 namespace: null
                 type: sqlite
             provider_id: huggingface
             provider_type: remote::huggingface
           - config:
               kvstore:
                 db_path: /Users/leseb/.llama/distributions/ollama/localfs_datasetio.db
                 namespace: null
                 type: sqlite
             provider_id: localfs
             provider_type: inline::localfs
           eval:
           - config:
               kvstore:
                 db_path: /Users/leseb/.llama/distributions/ollama/meta_reference_eval.db
                 namespace: null
                 type: sqlite
             provider_id: meta-reference
             provider_type: inline::meta-reference
           inference:
           - config:
               url: http://localhost:11434
             provider_id: ollama
             provider_type: remote::ollama
           - config: {}
             provider_id: sentence-transformers
             provider_type: inline::sentence-transformers
           post_training:
           - config:
               checkpoint_format: huggingface
               device: cpu
               distributed_backend: null
             provider_id: huggingface
             provider_type: inline::huggingface
           safety:
           - config:
               excluded_categories: []
             provider_id: llama-guard
             provider_type: inline::llama-guard
           scoring:
           - config: {}
             provider_id: basic
             provider_type: inline::basic
           - config: {}
             provider_id: llm-as-judge
             provider_type: inline::llm-as-judge
           - config:
               openai_api_key: '********'
             provider_id: braintrust
             provider_type: inline::braintrust
           telemetry:
           - config:
               service_name: "\u200B"
               sinks: console,sqlite
               sqlite_db_path: /Users/leseb/.llama/distributions/ollama/trace_store.db
             provider_id: meta-reference
             provider_type: inline::meta-reference
           tool_runtime:
           - config:
               api_key: '********'
               max_results: 3
             provider_id: brave-search
             provider_type: remote::brave-search
           - config:
               api_key: '********'
               max_results: 3
             provider_id: tavily-search
             provider_type: remote::tavily-search
           - config: {}
             provider_id: rag-runtime
             provider_type: inline::rag-runtime
           - config: {}
             provider_id: model-context-protocol
             provider_type: remote::model-context-protocol
           - config:
               api_key: '********'
             provider_id: wolfram-alpha
             provider_type: remote::wolfram-alpha
           vector_io:
           - config:
               kvstore:
                 db_path: /Users/leseb/.llama/distributions/ollama/faiss_store.db
                 namespace: null
                 type: sqlite
             provider_id: faiss
             provider_type: inline::faiss
         scoring_fns: []
         server:
           auth: null
           host: null
           port: 8321
           quota: null
           tls_cafile: null
           tls_certfile: null
           tls_keyfile: null
         shields: []
         tool_groups:
         - args: null
           mcp_endpoint: null
           provider_id: tavily-search
           toolgroup_id: builtin::websearch
         - args: null
           mcp_endpoint: null
           provider_id: rag-runtime
           toolgroup_id: builtin::rag
         - args: null
           mcp_endpoint: null
           provider_id: wolfram-alpha
           toolgroup_id: builtin::wolfram_alpha
         vector_dbs: []
         version: '2'

INFO     2025-06-18 10:51:41,721 llama_stack.providers.remote.inference.ollama.ollama:103 inference: checking
         connectivity to Ollama at `http://localhost:11434`...
INFO     2025-06-18 10:51:46,186 __main__:568 server: Listening on ['::', '0.0.0.0']:8321
INFO:     Started server process [64348]
INFO:     Waiting for application startup.
INFO     2025-06-18 10:51:46,193 __main__:155 server: Starting up
INFO:     Application startup complete.
INFO:     Uvicorn running on http://['::', '0.0.0.0']:8321 (Press CTRL+C to quit)
08:52:03.411 [START] /v1/providers
INFO:     ::1:54808 - "GET /v1/providers HTTP/1.1" 200 OK
08:52:03.424 [END] /v1/providers [StatusCode.OK] (13.42ms)
INFO:     ::1:54808 - "GET /v1/models HTTP/1.1" 200 OK
08:52:03.426 [START] /v1/models
INFO:     ::1:54808 - "GET /v1/models HTTP/1.1" 200 OK
08:52:03.428 [END] /v1/models [StatusCode.OK] (1.89ms)
INFO:     ::1:54808 - "GET /v1/vector-dbs HTTP/1.1" 200 OK
08:52:03.430 [START] /v1/models
INFO     2025-06-18 10:52:03,431 llama_stack.distribution.routing_tables.common:199 core: Setting owner for vector_db
         'test_vector_db' to
08:52:03.433 [END] /v1/models [StatusCode.OK] (3.27ms)
08:52:03.434 [START] /v1/vector-dbs
INFO:     ::1:54808 - "POST /v1/vector-dbs HTTP/1.1" 200 OK
08:52:03.436 [END] /v1/vector-dbs [StatusCode.OK] (2.49ms)
08:52:03.437 [START] /v1/vector-dbs
INFO:     ::1:54808 - "GET /v1/vector-dbs/test_vector_db HTTP/1.1" 200 OK
INFO:     ::1:54808 - "GET /v1/vector-dbs HTTP/1.1" 200 OK
08:52:03.442 [END] /v1/vector-dbs [StatusCode.OK] (4.62ms)
08:52:03.442 [START] /v1/vector-dbs/{vector_db_id:path}
INFO:     ::1:54808 - "DELETE /v1/vector-dbs/test_vector_db HTTP/1.1" 200 OK
INFO:     ::1:54808 - "GET /v1/vector-dbs HTTP/1.1" 200 OK
INFO     2025-06-18 10:52:03,446 llama_stack.distribution.routing_tables.common:199 core: Setting owner for vector_db
         'test_vector_db' to
08:52:03.444 [END] /v1/vector-dbs/{vector_db_id:path} [StatusCode.OK] (1.84ms)
08:52:03.447 [START] /v1/vector-dbs
08:52:03.448 [END] /v1/vector-dbs [StatusCode.OK] (1.57ms)
08:52:03.449 [START] /v1/vector-dbs/{vector_db_id:path}
INFO:     ::1:54808 - "POST /v1/vector-dbs HTTP/1.1" 200 OK
INFO:     ::1:54808 - "GET /v1/vector-dbs HTTP/1.1" 200 OK
INFO:     ::1:54808 - "DELETE /v1/vector-dbs/test_vector_db HTTP/1.1" 200 OK
INFO:     ::1:54808 - "GET /v1/vector-dbs HTTP/1.1" 200 OK
08:52:03.455 [END] /v1/vector-dbs/{vector_db_id:path} [StatusCode.OK] (6.07ms)
08:52:03.456 [START] /v1/vector-dbs
INFO:     ::1:54808 - "GET /v1/vector-dbs HTTP/1.1" 200 OK
08:52:03.458 [END] /v1/vector-dbs [StatusCode.OK] (1.25ms)
INFO:     ::1:54808 - "GET /v1/vector-dbs HTTP/1.1" 200 OK
08:52:03.459 [START] /v1/vector-dbs
INFO     2025-06-18 10:52:03,460 llama_stack.distribution.routing_tables.common:199 core: Setting owner for vector_db
         'test_vector_db' to
INFO:     ::1:54808 - "POST /v1/vector-dbs HTTP/1.1" 200 OK
08:52:03.464 [END] /v1/vector-dbs [StatusCode.OK] (4.90ms)
08:52:03.464 [START] /v1/vector-dbs
INFO     2025-06-18 10:52:03,466 llama_stack.providers.utils.inference.embedding_mixin:102 uncategorized: Loading
         sentence transformer for ibm-granite/granite-embedding-125m-english...
08:52:03.468 [END] /v1/vector-dbs [StatusCode.OK] (3.73ms)
08:52:03.470 [START] /v1/vector-dbs/{vector_db_id:path}
08:52:03.473 [END] /v1/vector-dbs/{vector_db_id:path} [StatusCode.OK] (3.04ms)
08:52:03.476 [START] /v1/vector-dbs
08:52:03.477 [END] /v1/vector-dbs [StatusCode.OK] (1.15ms)
08:52:03.478 [START] /v1/vector-dbs
08:52:03.480 [END] /v1/vector-dbs [StatusCode.OK] (1.42ms)
08:52:03.480 [START] /v1/vector-dbs
08:52:03.481 [END] /v1/vector-dbs [StatusCode.OK] (1.19ms)
08:52:03.483 [START] /v1/vector-dbs
08:52:03.485 [END] /v1/vector-dbs [StatusCode.OK] (2.64ms)
08:52:03.486 [START] /v1/vector-io/insert
INFO     2025-06-18 10:52:03,538 sentence_transformers.SentenceTransformer:211 uncategorized: Use pytorch device_name:
         mps
INFO     2025-06-18 10:52:03,538 sentence_transformers.SentenceTransformer:219 uncategorized: Load pretrained
         SentenceTransformer: ibm-granite/granite-embedding-125m-english
INFO:     ::1:54808 - "POST /v1/vector-io/insert HTTP/1.1" 200 OK
08:52:07.866 [END] /v1/vector-io/insert [StatusCode.OK] (4380.06ms)
08:52:07.870 [START] /v1/vector-io/query
INFO:     ::1:54808 - "POST /v1/vector-io/query HTTP/1.1" 200 OK
08:52:08.053 [END] /v1/vector-io/query [StatusCode.OK] (182.89ms)
08:52:08.057 [START] /v1/vector-io/query
INFO:     ::1:54808 - "POST /v1/vector-io/query HTTP/1.1" 200 OK
INFO:     ::1:54808 - "GET /v1/vector-dbs HTTP/1.1" 200 OK
08:52:08.140 [END] /v1/vector-io/query [StatusCode.OK] (83.38ms)
08:52:08.142 [START] /v1/vector-dbs
08:52:08.144 [END] /v1/vector-dbs [StatusCode.OK] (2.12ms)
INFO:     ::1:54808 - "DELETE /v1/vector-dbs/test_vector_db HTTP/1.1" 200 OK
08:52:08.145 [START] /v1/vector-dbs/{vector_db_id:path}
INFO:     ::1:54808 - "GET /v1/vector-dbs HTTP/1.1" 200 OK
INFO     2025-06-18 10:52:08,149 llama_stack.distribution.routing_tables.common:199 core: Setting owner for vector_db
         'test_vector_db' to
08:52:08.152 [END] /v1/vector-dbs/{vector_db_id:path} [StatusCode.OK] (7.16ms)
08:52:08.154 [START] /v1/vector-dbs
INFO:     ::1:54808 - "POST /v1/vector-dbs HTTP/1.1" 200 OK
08:52:08.157 [END] /v1/vector-dbs [StatusCode.OK] (2.71ms)
08:52:08.158 [START] /v1/vector-dbs
08:52:08.163 [END] /v1/vector-dbs [StatusCode.OK] (5.65ms)
08:52:08.164 [START] /v1/vector-io/insert
INFO:     ::1:54808 - "POST /v1/vector-io/insert HTTP/1.1" 200 OK
08:52:08.206 [END] /v1/vector-io/insert [StatusCode.OK] (41.60ms)
08:52:08.207 [START] /v1/vector-io/query
INFO:     ::1:54808 - "POST /v1/vector-io/query HTTP/1.1" 200 OK
08:52:08.231 [END] /v1/vector-io/query [StatusCode.OK] (23.74ms)
08:52:08.232 [START] /v1/vector-io/query
INFO:     ::1:54808 - "POST /v1/vector-io/query HTTP/1.1" 200 OK
INFO:     ::1:54808 - "GET /v1/vector-dbs HTTP/1.1" 200 OK
08:52:08.330 [END] /v1/vector-io/query [StatusCode.OK] (97.16ms)
08:52:08.331 [START] /v1/vector-dbs
08:52:08.333 [END] /v1/vector-dbs [StatusCode.OK] (1.96ms)
08:52:08.335 [START] /v1/vector-dbs/{vector_db_id:path}
INFO:     ::1:54808 - "DELETE /v1/vector-dbs/test_vector_db HTTP/1.1" 200 OK
INFO:     ::1:54808 - "GET /v1/vector-dbs HTTP/1.1" 200 OK
08:52:08.339 [END] /v1/vector-dbs/{vector_db_id:path} [StatusCode.OK] (4.31ms)
INFO     2025-06-18 10:52:08,341 llama_stack.distribution.routing_tables.common:199 core: Setting owner for vector_db
         'test_vector_db' to
08:52:08.342 [START] /v1/vector-dbs
INFO:     ::1:54808 - "POST /v1/vector-dbs HTTP/1.1" 200 OK
08:52:08.346 [END] /v1/vector-dbs [StatusCode.OK] (3.34ms)
08:52:08.346 [START] /v1/vector-dbs
08:52:08.356 [END] /v1/vector-dbs [StatusCode.OK] (9.12ms)
08:52:08.357 [START] /v1/vector-io/insert
INFO:     ::1:54808 - "POST /v1/vector-io/insert HTTP/1.1" 200 OK
08:52:08.397 [END] /v1/vector-io/insert [StatusCode.OK] (40.66ms)
08:52:08.398 [START] /v1/vector-io/query
INFO:     ::1:54808 - "POST /v1/vector-io/query HTTP/1.1" 200 OK
08:52:08.420 [END] /v1/vector-io/query [StatusCode.OK] (21.98ms)
08:52:08.421 [START] /v1/vector-io/query
INFO:     ::1:54808 - "POST /v1/vector-io/query HTTP/1.1" 200 OK
INFO:     ::1:54808 - "GET /v1/vector-dbs HTTP/1.1" 200 OK
08:52:08.493 [END] /v1/vector-io/query [StatusCode.OK] (71.75ms)
08:52:08.494 [START] /v1/vector-dbs
08:52:08.495 [END] /v1/vector-dbs [StatusCode.OK] (1.35ms)
08:52:08.496 [START] /v1/vector-dbs/{vector_db_id:path}
INFO:     ::1:54808 - "DELETE /v1/vector-dbs/test_vector_db HTTP/1.1" 200 OK
INFO:     ::1:54808 - "GET /v1/vector-dbs HTTP/1.1" 200 OK
INFO     2025-06-18 10:52:08,501 llama_stack.distribution.routing_tables.common:199 core: Setting owner for vector_db
         'test_vector_db' to
08:52:08.500 [END] /v1/vector-dbs/{vector_db_id:path} [StatusCode.OK] (4.28ms)
08:52:08.503 [START] /v1/vector-dbs
08:52:08.505 [END] /v1/vector-dbs [StatusCode.OK] (2.11ms)
INFO:     ::1:54808 - "POST /v1/vector-dbs HTTP/1.1" 200 OK
08:52:08.507 [START] /v1/vector-dbs
08:52:08.512 [END] /v1/vector-dbs [StatusCode.OK] (5.74ms)
08:52:08.515 [START] /v1/vector-io/insert
INFO:     ::1:54808 - "POST /v1/vector-io/insert HTTP/1.1" 200 OK
08:52:08.557 [END] /v1/vector-io/insert [StatusCode.OK] (42.47ms)
08:52:08.558 [START] /v1/vector-io/query
INFO:     ::1:54808 - "POST /v1/vector-io/query HTTP/1.1" 200 OK
08:52:08.585 [END] /v1/vector-io/query [StatusCode.OK] (26.55ms)
08:52:08.586 [START] /v1/vector-io/query
INFO:     ::1:54808 - "POST /v1/vector-io/query HTTP/1.1" 200 OK
INFO:     ::1:54808 - "GET /v1/vector-dbs HTTP/1.1" 200 OK
08:52:08.611 [END] /v1/vector-io/query [StatusCode.OK] (25.48ms)
08:52:08.612 [START] /v1/vector-dbs
08:52:08.613 [END] /v1/vector-dbs [StatusCode.OK] (1.19ms)
INFO:     ::1:54808 - "DELETE /v1/vector-dbs/test_vector_db HTTP/1.1" 200 OK
08:52:08.614 [START] /v1/vector-dbs/{vector_db_id:path}
INFO:     ::1:54808 - "GET /v1/vector-dbs HTTP/1.1" 200 OK
INFO     2025-06-18 10:52:08,618 llama_stack.distribution.routing_tables.common:199 core: Setting owner for vector_db
         'test_vector_db' to
08:52:08.620 [END] /v1/vector-dbs/{vector_db_id:path} [StatusCode.OK] (5.45ms)
08:52:08.621 [START] /v1/vector-dbs
INFO:     ::1:54808 - "POST /v1/vector-dbs HTTP/1.1" 200 OK
08:52:08.622 [END] /v1/vector-dbs [StatusCode.OK] (1.26ms)
08:52:08.623 [START] /v1/vector-dbs
08:52:08.629 [END] /v1/vector-dbs [StatusCode.OK] (5.63ms)
08:52:08.630 [START] /v1/vector-io/insert
INFO:     ::1:54808 - "POST /v1/vector-io/insert HTTP/1.1" 200 OK
08:52:08.677 [END] /v1/vector-io/insert [StatusCode.OK] (47.16ms)
08:52:08.678 [START] /v1/vector-io/query
INFO:     ::1:54808 - "POST /v1/vector-io/query HTTP/1.1" 200 OK
08:52:08.702 [END] /v1/vector-io/query [StatusCode.OK] (24.76ms)
08:52:08.704 [START] /v1/vector-io/query
INFO:     ::1:54808 - "POST /v1/vector-io/query HTTP/1.1" 200 OK
INFO:     ::1:54808 - "GET /v1/vector-dbs HTTP/1.1" 200 OK
08:52:08.725 [END] /v1/vector-io/query [StatusCode.OK] (21.38ms)
08:52:08.726 [START] /v1/vector-dbs
08:52:08.728 [END] /v1/vector-dbs [StatusCode.OK] (1.95ms)
08:52:08.729 [START] /v1/vector-dbs/{vector_db_id:path}
INFO:     ::1:54808 - "DELETE /v1/vector-dbs/test_vector_db HTTP/1.1" 200 OK
INFO:     ::1:54808 - "GET /v1/vector-dbs HTTP/1.1" 200 OK
INFO     2025-06-18 10:52:08,733 llama_stack.distribution.routing_tables.common:199 core: Setting owner for vector_db
         'test_precomputed_embeddings_db' to
08:52:08.735 [END] /v1/vector-dbs/{vector_db_id:path} [StatusCode.OK] (5.55ms)
08:52:08.736 [START] /v1/vector-dbs
INFO:     ::1:54808 - "POST /v1/vector-dbs HTTP/1.1" 200 OK
08:52:08.739 [END] /v1/vector-dbs [StatusCode.OK] (2.71ms)
08:52:08.739 [START] /v1/vector-dbs
INFO:     ::1:54808 - "POST /v1/vector-io/insert HTTP/1.1" 200 OK
08:52:08.753 [END] /v1/vector-dbs [StatusCode.OK] (14.10ms)
08:52:08.755 [START] /v1/vector-io/insert
08:52:08.757 [END] /v1/vector-io/insert [StatusCode.OK] (2.24ms)
08:52:08.757 [START] /v1/vector-io/query
INFO:     ::1:54808 - "POST /v1/vector-io/query HTTP/1.1" 200 OK
INFO:     ::1:54808 - "GET /v1/vector-dbs HTTP/1.1" 200 OK
08:52:08.823 [END] /v1/vector-io/query [StatusCode.OK] (65.55ms)
08:52:08.824 [START] /v1/vector-dbs
INFO:     ::1:54808 - "DELETE /v1/vector-dbs/test_precomputed_embeddings_db HTTP/1.1" 200 OK
08:52:08.826 [END] /v1/vector-dbs [StatusCode.OK] (1.42ms)
08:52:08.827 [START] /v1/vector-dbs/{vector_db_id:path}
08:52:08.833 [END] /v1/vector-dbs/{vector_db_id:path} [StatusCode.OK] (5.17ms)
```

Ran the suite test:

```
 pytest -s -vvv tests/integration/vector_io/test_vector_io.py --stack-config=http://localhost:8321 \
    -k "not(builtin_tool or safety_with_image or code_interpreter or test_rag)" \
    --text-model="meta-llama/Llama-3.2-3B-Instruct" \
    --embedding-model=granite-embedding-125m --embedding-dimension=768
INFO     2025-06-18 10:52:03,314 tests.integration.conftest:59 tests: Setting DISABLE_CODE_SANDBOX=1 for macOS
/Users/leseb/Documents/AI/llama-stack/.venv/lib/python3.10/site-packages/pytest_asyncio/plugin.py:207: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
================================================= test session starts =================================================
platform darwin -- Python 3.10.16, pytest-8.3.4, pluggy-1.5.0 -- /Users/leseb/Documents/AI/llama-stack/.venv/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.10.16', 'Platform': 'macOS-15.5-arm64-arm-64bit', 'Packages': {'pytest': '8.3.4', 'pluggy': '1.5.0'}, 'Plugins': {'cov': '6.0.0', 'html': '4.1.1', 'json-report': '1.5.0', 'timeout': '2.4.0', 'metadata': '3.1.1', 'asyncio': '0.25.3', 'anyio': '4.8.0', 'nbval': '0.11.0'}}
rootdir: /Users/leseb/Documents/AI/llama-stack
configfile: pyproject.toml
plugins: cov-6.0.0, html-4.1.1, json-report-1.5.0, timeout-2.4.0, metadata-3.1.1, asyncio-0.25.3, anyio-4.8.0, nbval-0.11.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None
collected 8 items

tests/integration/vector_io/test_vector_io.py::test_vector_db_retrieve[emb=granite-embedding-125m:dim=768] PASSED
tests/integration/vector_io/test_vector_io.py::test_vector_db_register[emb=granite-embedding-125m:dim=768] PASSED
tests/integration/vector_io/test_vector_io.py::test_insert_chunks[emb=granite-embedding-125m:dim=768-test_case0] PASSED
tests/integration/vector_io/test_vector_io.py::test_insert_chunks[emb=granite-embedding-125m:dim=768-test_case1] PASSED
tests/integration/vector_io/test_vector_io.py::test_insert_chunks[emb=granite-embedding-125m:dim=768-test_case2] PASSED
tests/integration/vector_io/test_vector_io.py::test_insert_chunks[emb=granite-embedding-125m:dim=768-test_case3] PASSED
tests/integration/vector_io/test_vector_io.py::test_insert_chunks[emb=granite-embedding-125m:dim=768-test_case4] PASSED
tests/integration/vector_io/test_vector_io.py::test_insert_chunks_with_precomputed_embeddings[emb=granite-embedding-125m:dim=768] PASSED

================================================== 8 passed in 5.50s ==================================================
```
