### PR TITLE
chore: Bump TrustyAI LMEval provider version

### DIFF
--- a/redhat-distribution/Containerfile
+++ b/redhat-distribution/Containerfile
@@ -15,7 +15,7 @@ RUN pip install \
     fire \
     httpx \
     kubernetes \
-    llama_stack_provider_lmeval==0.1.5 \
+    llama_stack_provider_lmeval==0.1.7 \
     llama_stack_provider_trustyai_fms==0.1.2 \
     matplotlib \
     mcp \

--- a/redhat-distribution/providers.d/remote/eval/trustyai_lmeval.yaml
+++ b/redhat-distribution/providers.d/remote/eval/trustyai_lmeval.yaml
@@ -1,6 +1,6 @@
 adapter:
   adapter_type: trustyai_lmeval
-  pip_packages: ["kubernetes", "llama_stack_provider_lmeval==0.1.5"]
+  pip_packages: ["kubernetes", "llama_stack_provider_lmeval==0.1.7"]
   config_class: llama_stack_provider_lmeval.config.LMEvalEvalProviderConfig
   module: llama_stack_provider_lmeval
 api_dependencies: ["inference"]


### PR DESCRIPTION
Bump TrustyAI LMEval version to incorporate fix for https://github.com/trustyai-explainability/llama-stack-provider-lmeval/issues/37

Depends on https://github.com/opendatahub-io/llama-stack/pull/16