### PR TITLE
fix: pin opentelemetry

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,7 +124,7 @@ repos:
         always_run: true
         files: ^redhat-distribution/.*$
         additional_dependencies:
-          - llama-stack==0.2.10
+          - llama-stack==0.2.14
 
 
 ci:

--- a/redhat-distribution/Containerfile
+++ b/redhat-distribution/Containerfile
@@ -22,12 +22,12 @@ RUN pip install \
     nltk \
     numpy \
     openai \
-    opentelemetry-exporter-otlp-proto-http \
-    opentelemetry-sdk \
+    opentelemetry-exporter-otlp-proto-http>=1.30.0 \
+    opentelemetry-sdk>=1.30.0 \
     pandas \
     pillow \
     psycopg2-binary \
-    pymilvus \
+    pymilvus>=2.4.10 \
     pymongo \
     pypdf \
     redis \

--- a/redhat-distribution/build.py
+++ b/redhat-distribution/build.py
@@ -56,6 +56,16 @@ def get_dependencies():
                 else:
                     standard_deps.append(" ".join(parts))
 
+        # HACK ALERT: We need to pin the opentelemetry-sdk and
+        # opentelemetry-exporter-otlp-proto-http
+        # This is a temporary fix until we can upgrade to llama-stack 0.2.15
+        # See https://github.com/meta-llama/llama-stack/pull/2722
+        standard_deps = [dep.replace("opentelemetry-sdk", "opentelemetry-sdk>=1.30.0") for dep in standard_deps]
+        standard_deps = [
+            dep.replace("opentelemetry-exporter-otlp-proto-http", "opentelemetry-exporter-otlp-proto-http>=1.30.0")
+            for dep in standard_deps
+        ]
+
         # Combine all dependencies in specific order
         all_deps = []
         all_deps.extend(sorted(standard_deps))  # Regular pip installs first


### PR DESCRIPTION
The upstream fix is in
https://github.com/meta-llama/llama-stack/pull/2722. But we won't likely be pulling 0.1.15, we might not have it in time.