### PR TITLE
chore: Add latest tag when building lls images [rhoai-v2.23]

### DIFF
--- a/.github/workflows/redhat-distro-container-build.yml
+++ b/.github/workflows/redhat-distro-container-build.yml
@@ -13,10 +13,8 @@ on:
 
 env:
   REGISTRY: quay.io
-  # TODO: change the tag to whatever downstream needs
-  # IMAGE_NAME: quay.io/opendatahub/llama-stack:odh
-  # For now, use the commit SHA that triggered the workflow.
-  IMAGE_NAME: quay.io/opendatahub/llama-stack:${{ github.sha }}
+  IMAGE_NAME: quay.io/opendatahub/llama-stack
+  BRANCH: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   build-and-push:
@@ -52,4 +50,4 @@ jobs:
           file: redhat-distribution/Containerfile
           platforms: ${{ matrix.platform }}
           push: ${{ github.event_name == 'push' }}
-          tags: ${{ env.IMAGE_NAME }}
+          tags: ${{ env.IMAGE_NAME }}:${{ github.sha }},${{ env.IMAGE_NAME }}:${{ env.BRANCH }}-latest


### PR DESCRIPTION
# What does this PR do?
Adds latest tag for images built from `rhoai-v2.23` branch. 

This can then be cherry-picked to other branches as needed (or new PRs can be opened)
