### PR TITLE
refactor: switch build.yaml to use the new format

### DIFF
--- a/redhat-distribution/build.yaml
+++ b/redhat-distribution/build.yaml
@@ -3,30 +3,31 @@ distribution_spec:
   description: Red Hat distribution of Llama Stack
   providers:
     inference:
-    - remote::vllm
-    - inline::sentence-transformers
+    - provider_type: remote::vllm
     vector_io:
-    - inline::milvus
+    - provider_type: inline::milvus
     safety:
-    - remote::trustyai_fms
+    - provider_type: remote::trustyai_fms
+      module: llama_stack_provider_trustyai_fms==0.1.7
     agents:
-    - inline::meta-reference
+    - provider_type: inline::meta-reference
     eval:
-    - remote::trustyai_lmeval
+    - provider_type: remote::trustyai_lmeval
+      module: llama_stack_provider_lmeval
     datasetio:
-    - remote::huggingface
-    - inline::localfs
+    - provider_type: remote::huggingface
+    - provider_type: inline::localfs
     scoring:
-    - inline::basic
-    - inline::llm-as-judge
-    - inline::braintrust
+    - provider_type: inline::basic
+    - provider_type: inline::llm-as-judge
+    - provider_type: inline::braintrust
     telemetry:
-    - inline::meta-reference
+    - provider_type: inline::meta-reference
     tool_runtime:
-    - remote::brave-search
-    - remote::tavily-search
-    - inline::rag-runtime
-    - remote::model-context-protocol
+    - provider_type: remote::brave-search
+    - provider_type: remote::tavily-search
+    - provider_type: inline::rag-runtime
+    - provider_type: remote::model-context-protocol
   container_image: registry.redhat.io/ubi9/python-311:9.6-1749631027
 additional_pip_packages:
 - aiosqlite

--- a/redhat-distribution/providers.d/remote/eval/trustyai_lmeval.yaml
+++ b/redhat-distribution/providers.d/remote/eval/trustyai_lmeval.yaml
@@ -1,7 +1,0 @@
-adapter:
-  adapter_type: trustyai_lmeval
-  pip_packages: ["kubernetes", "llama_stack_provider_lmeval==0.1.7"]
-  config_class: llama_stack_provider_lmeval.config.LMEvalEvalProviderConfig
-  module: llama_stack_provider_lmeval
-api_dependencies: ["inference"]
-optional_api_dependencies: []

--- a/redhat-distribution/providers.d/remote/safety/trustyai_fms.yaml
+++ b/redhat-distribution/providers.d/remote/safety/trustyai_fms.yaml
@@ -1,7 +1,0 @@
-adapter:
-  adapter_type: trustyai_fms
-  pip_packages: ["llama_stack_provider_trustyai_fms==0.1.2"]
-  config_class: llama_stack_provider_trustyai_fms.config.FMSSafetyProviderConfig
-  module: llama_stack_provider_trustyai_fms
-api_dependencies: ["safety"]
-optional_api_dependencies: ["shields"]

--- a/redhat-distribution/run.yaml
+++ b/redhat-distribution/run.yaml
@@ -34,6 +34,7 @@ providers:
   safety:
     - provider_id: trustyai_fms
       provider_type: remote::trustyai_fms
+      module: llama_stack_provider_trustyai_fms==0.1.7
       config:
         orchestrator_url: ${env.FMS_ORCHESTRATOR_URL:=}
         ssl_cert_path: ${env.FMS_SSL_CERT_PATH:=}
@@ -52,6 +53,7 @@ providers:
   eval:
   - provider_id: trustyai_lmeval
     provider_type: remote::trustyai_lmeval
+    module: llama_stack_provider_lmeval
     config:
         use_k8s: True
         base_url: ${env.VLLM_URL:=http://localhost:8000/v1}


### PR DESCRIPTION
# What does this PR do?

new build format and external provider heuristic introduced in meta-llama/llama-stack#2673

switch to this format in the build.yaml and run.yaml, other changes to come

